### PR TITLE
Update freedombone

### DIFF
--- a/src/freedombone
+++ b/src/freedombone
@@ -6592,19 +6592,19 @@ function install_wiki {
   sed -i "s/@admin/$MY_USERNAME/g" /etc/dokuwiki/local.php
 
   # disallow registration of new users
-  if ! grep -q "disableactions" /etc/dokuwiki/local.php; then
-      echo "$conf['disableactions'] = 'register'" >> /etc/dokuwiki/local.php
-  fi
-  if ! grep -q "disableactions" /var/lib/dokuwiki/custom/local.php; then
-      echo "$conf['disableactions'] = 'register';" >> /var/lib/dokuwiki/custom/local.php
-  fi
+  #if ! grep -q "disableactions" /etc/dokuwiki/local.php; then
+  #    echo "$conf['disableactions'] = 'register';" >> /etc/dokuwiki/local.php
+  #fi
+  #if ! grep -q "disableactions" /var/lib/dokuwiki/custom/local.php; then
+  #    echo "$conf['disableactions'] = 'register';" >> /var/lib/dokuwiki/custom/local.php
+  #fi
 
-  if ! grep -q "authtype" /var/lib/dokuwiki/custom/local.php; then
-      echo "$conf['authtype'] = 'authplain';" >> /var/lib/dokuwiki/custom/local.php
-  fi
-  if ! grep -q "authtype" /etc/dokuwiki/local.php; then
-      echo "$conf['authtype'] = 'authplain';" >> /etc/dokuwiki/local.php
-  fi
+  #if ! grep -q "authtype" /var/lib/dokuwiki/custom/local.php; then
+  #    echo "$conf['authtype'] = 'authplain';" >> /var/lib/dokuwiki/custom/local.php
+  #fi
+  #if ! grep -q "authtype" /etc/dokuwiki/local.php; then
+  #    echo "$conf['authtype'] = 'authplain';" >> /etc/dokuwiki/local.php
+ #fi
 
   get_wiki_admin_password
   if [ ! $WIKI_ADMIN_PASSWORD ]; then

--- a/src/freedombone
+++ b/src/freedombone
@@ -6592,19 +6592,19 @@ function install_wiki {
   sed -i "s/@admin/$MY_USERNAME/g" /etc/dokuwiki/local.php
 
   # disallow registration of new users
-  #if ! grep -q "disableactions" /etc/dokuwiki/local.php; then
-  #    echo "$conf['disableactions'] = 'register';" >> /etc/dokuwiki/local.php
-  #fi
-  #if ! grep -q "disableactions" /var/lib/dokuwiki/custom/local.php; then
-  #    echo "$conf['disableactions'] = 'register';" >> /var/lib/dokuwiki/custom/local.php
-  #fi
+  if ! grep -q "disableactions" /etc/dokuwiki/local.php; then
+      echo "\$conf['disableactions'] = 'register';" >> /etc/dokuwiki/local.php
+  fi
+  if ! grep -q "disableactions" /var/lib/dokuwiki/custom/local.php; then
+      echo "\$conf['disableactions'] = 'register';" >> /var/lib/dokuwiki/custom/local.php
+  fi
 
-  #if ! grep -q "authtype" /var/lib/dokuwiki/custom/local.php; then
-  #    echo "$conf['authtype'] = 'authplain';" >> /var/lib/dokuwiki/custom/local.php
-  #fi
-  #if ! grep -q "authtype" /etc/dokuwiki/local.php; then
-  #    echo "$conf['authtype'] = 'authplain';" >> /etc/dokuwiki/local.php
- #fi
+  if ! grep -q "authtype" /var/lib/dokuwiki/custom/local.php; then
+      echo "\$conf['authtype'] = 'authplain';" >> /var/lib/dokuwiki/custom/local.php
+  fi
+  if ! grep -q "authtype" /etc/dokuwiki/local.php; then
+      echo "\$conf['authtype'] = 'authplain';" >> /etc/dokuwiki/local.php
+ fi
 
   get_wiki_admin_password
   if [ ! $WIKI_ADMIN_PASSWORD ]; then


### PR DESCRIPTION
These settings cause PHP to throw an error. Bash can't echo "$conf" because bash isent that smart. Fixed it by adding "\$conf".