### PR TITLE
include IMAP port 993

### DIFF
--- a/src/freedombone
+++ b/src/freedombone
@@ -4885,7 +4885,7 @@ function configure_email {
 
   sed -i '/login_saslauthd_server/,/.endif/ s/# *//' /etc/exim4/exim4.conf.template
   sed -i "/.ifdef MAIN_HARDCODE_PRIMARY_HOSTNAME/i\MAIN_HARDCODE_PRIMARY_HOSTNAME = $DEFAULT_DOMAIN_NAME\nMAIN_TLS_ENABLE = true" /etc/exim4/exim4.conf.template
-  sed -i "s|SMTPLISTENEROPTIONS=''|SMTPLISTENEROPTIONS='-oX 465:25:587 -oP /var/run/exim4/exim.pid'|g" /etc/default/exim4
+  sed -i "s|SMTPLISTENEROPTIONS=''|SMTPLISTENEROPTIONS='-oX 465:25:587:993 -oP /var/run/exim4/exim.pid'|g" /etc/default/exim4
   if ! grep -q "tls_on_connect_ports=465" /etc/exim4/exim4.conf.template; then
     sed -i '/SSL configuration for exim/i\tls_on_connect_ports=465' /etc/exim4/exim4.conf.template
   fi


### PR DESCRIPTION
I was following the usage.html guide and it said to use "Incoming: IMAP, mydomainname.com, 993, SSL/TLS, Normal Password ". My thunderbird client could not connect to my freedombone server. In my investigation I noticed port 993 was closed on my freedombone, and it probably needs to be open for this connection to work. 

Oddly enough I still can't connect even after restarting exim4 and verifying port 993 is open, so there must be more to it. 