### PR TITLE
Dyamically get the `freedombone` command

### DIFF
--- a/src/freedombone-prep
+++ b/src/freedombone-prep
@@ -243,7 +243,7 @@ $SUDO sed -i "s/nameserver.*/nameserver $NAMESERVER1/g" $MICROSD_MOUNT_POINT/$RO
 $SUDO sed -i "/nameserver $NAMESERVER1/a\nameserver $NAMESERVER2" $MICROSD_MOUNT_POINT/$ROOTFS/etc/resolv.conf
 
 # copy the commands to the card
-$SUDO cp -f /usr/local/bin/freedombone* $MICROSD_MOUNT_POINT/$ROOTFS/usr/local/bin/
+$SUDO cp -f $(which freedombone)* $MICROSD_MOUNT_POINT/$ROOTFS/usr/local/bin/
 if [ ! -f $MICROSD_MOUNT_POINT/$ROOTFS/usr/local/bin/freedombone ]; then
     echo 'There was a problem with writing freedombone commands to the SD card'
     exit 8736


### PR DESCRIPTION
If you install the freedombone commands manually, the scripts are placed in `usr/local/bin`, while installing it as a Debian package puts them in `usr/bin`. So `freedombone-prep` fails to copy the commands to my BBB when you install them as a Debian package. This should fix it!

(note: this is one of the first times I'm contributing to an open source project, so I hope this is the correct way to do so!)